### PR TITLE
Mark input args as readonly since functions are pure

### DIFF
--- a/.changeset/light-drinks-own.md
+++ b/.changeset/light-drinks-own.md
@@ -1,0 +1,5 @@
+---
+'array-fp-utils': minor
+---
+
+Mark input args as Readonly since functions are pure.

--- a/lib/groupBy/groupBy.ts
+++ b/lib/groupBy/groupBy.ts
@@ -2,7 +2,7 @@ import { NonEmptyArray } from '../types';
 
 export const groupBy =
   <ValueType, KeyType>(getKey: (value: ValueType) => KeyType) =>
-  (arr: Array<ValueType>): Array<NonEmptyArray<ValueType>> => {
+  (arr: Readonly<Array<ValueType>>): Array<NonEmptyArray<ValueType>> => {
     const map = arr.reduce((acc, value) => {
       const key = getKey(value);
       const group = acc.get(key);

--- a/lib/intersect/intersect.ts
+++ b/lib/intersect/intersect.ts
@@ -1,6 +1,6 @@
 export const intersect =
-  (otherArr: Array<unknown>) =>
-  <ValueType>(arr: Array<ValueType>): Array<ValueType> => {
+  (otherArr: Readonly<Array<unknown>>) =>
+  <ValueType>(arr: Readonly<Array<ValueType>>): Array<ValueType> => {
     const set = new Set(otherArr);
 
     return arr.filter((item) => set.has(item));

--- a/lib/intersectWith/intersectWith.ts
+++ b/lib/intersectWith/intersectWith.ts
@@ -1,9 +1,9 @@
 export const intersectWith =
   <ValueType, OtherValueType>(
-    otherArr: Array<OtherValueType>,
+    otherArr: Readonly<Array<OtherValueType>>,
     isEqual: (value: ValueType, otherValue: OtherValueType) => boolean
   ) =>
-  (arr: Array<ValueType>): Array<ValueType> => {
+  (arr: Readonly<Array<ValueType>>): Array<ValueType> => {
     return arr.filter((item) =>
       otherArr.some((otherItem) => isEqual(item, otherItem))
     );

--- a/lib/isDistinctArray/isDistinctArray.ts
+++ b/lib/isDistinctArray/isDistinctArray.ts
@@ -1,4 +1,6 @@
-export function isDistinctArray<ValueType>(arr: Array<ValueType>): boolean {
+export function isDistinctArray<ValueType>(
+  arr: Readonly<Array<ValueType>>
+): boolean {
   const set = new Set(arr);
   return arr.length === set.size;
 }

--- a/lib/isSubsetOf/isSubsetOf.ts
+++ b/lib/isSubsetOf/isSubsetOf.ts
@@ -1,6 +1,6 @@
 export const isSubsetOf =
-  <ValueType>(otherArr: Array<ValueType>) =>
-  (arr: Array<ValueType>): boolean => {
+  <ValueType>(otherArr: Readonly<Array<ValueType>>) =>
+  (arr: Readonly<Array<ValueType>>): boolean => {
     const set = new Set(otherArr);
     return arr.every((item) => set.has(item));
   };

--- a/lib/isSubsetOfWith/isSubsetOfWith.ts
+++ b/lib/isSubsetOfWith/isSubsetOfWith.ts
@@ -1,9 +1,9 @@
 export const isSubsetOfWith =
   <ValueType, OtherValueType>(
-    otherArr: Array<OtherValueType> | Readonly<Array<OtherValueType>>,
+    otherArr: Readonly<Array<OtherValueType>>,
     isEqual: (value: ValueType, otherValue: OtherValueType) => boolean
   ) =>
-  (arr: Array<ValueType> | Readonly<Array<ValueType>>): boolean => {
+  (arr: Readonly<Array<ValueType>>): boolean => {
     return arr.every((item) =>
       otherArr.some((otherItem) => isEqual(item, otherItem))
     );

--- a/lib/unique/unique.ts
+++ b/lib/unique/unique.ts
@@ -1,3 +1,5 @@
-export const unique = <ValueType>(arr: Array<ValueType>): Array<ValueType> => {
+export const unique = <ValueType>(
+  arr: Readonly<Array<ValueType>>
+): Array<ValueType> => {
   return Array.from(new Set(arr));
 };

--- a/lib/uniqueBy/uniqueBy.ts
+++ b/lib/uniqueBy/uniqueBy.ts
@@ -5,7 +5,7 @@ export const uniqueBy =
       prevValue
     ) => prevValue
   ) =>
-  (arr: Array<ValueType>): Array<ValueType> => {
+  (arr: Readonly<Array<ValueType>>): Array<ValueType> => {
     const map = arr.reduce((acc, value) => {
       const key = getUniqueKey(value);
       const existingValue = acc.get(key);


### PR DESCRIPTION
Note this change is backwards compatible with writable args since typescript treats readonly args as a superset of writable args.