### PR TITLE
Update unique() to accept non-empty array and return likewise

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,9 @@
 export type NonEmptyArray<T> = [T, ...T[]];
 
+export type NonEmptyArrayAlt<A> = Array<A> & {
+  0: A;
+};
+
 export type Primitive =
   | string
   | number

--- a/lib/unique/unique.test.ts
+++ b/lib/unique/unique.test.ts
@@ -1,5 +1,3 @@
-import { pipe } from 'fp-ts/lib/function';
-
 import { unique } from './unique';
 
 const mockData = [
@@ -17,7 +15,7 @@ const mockData = [
 
 describe('unique()', () => {
   it('returns unique values', () => {
-    const expected = pipe(mockData, unique);
+    const expected = unique(mockData);
 
     expect(expected).toMatchInlineSnapshot(`
       [

--- a/lib/unique/unique.ts
+++ b/lib/unique/unique.ts
@@ -9,11 +9,11 @@ export function unique<ValueType extends Primitive>(
 ): NonEmptyArrayAlt<ValueType>;
 
 export function unique<ValueType extends Primitive>(
-  arr: Readonly<Array<ValueType>>
+  arr: ReadonlyArray<ValueType>
 ): Array<ValueType>;
 
 export function unique<ValueType extends Primitive>(
-  arr: Readonly<Array<ValueType>>
+  arr: ReadonlyArray<ValueType>
 ) {
   return Array.from(new Set(arr));
 }

--- a/lib/unique/unique.ts
+++ b/lib/unique/unique.ts
@@ -1,5 +1,19 @@
-import { Primitive } from '../types';
+import { NonEmptyArray, NonEmptyArrayAlt, Primitive } from '../types';
 
-export const unique = (arr: Readonly<Array<Primitive>>): Array<Primitive> => {
+export function unique<ValueType extends Primitive>(
+  arr: Readonly<NonEmptyArray<ValueType>>
+): NonEmptyArray<ValueType>;
+
+export function unique<ValueType extends Primitive>(
+  arr: Readonly<NonEmptyArrayAlt<ValueType>>
+): NonEmptyArrayAlt<ValueType>;
+
+export function unique<ValueType extends Primitive>(
+  arr: Readonly<Array<ValueType>>
+): Array<ValueType>;
+
+export function unique<ValueType extends Primitive>(
+  arr: Readonly<Array<ValueType>>
+) {
   return Array.from(new Set(arr));
-};
+}


### PR DESCRIPTION
When a `NonEmptyArray` is being passed to `unique()` the output will always be a `NonEmptyArray`. Use function overloading to declare the correct types.