### PR TITLE
chore: add types in the exports section of package.json

### DIFF
--- a/.changeset/quick-baboons-melt.md
+++ b/.changeset/quick-baboons-melt.md
@@ -1,0 +1,5 @@
+---
+'array-fp-utils': minor
+---
+
+Add a types section on the exports section of package.json file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "array-fp-utils",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "array-fp-utils",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.6",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
         "import": "./dist/esm/index.js",
         "require": "./dist/cjs/index.js"
       },
-      "default": "./dist/esm/index.js"
+      "default": "./dist/esm/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
This PR adds a `types` section on the package.json `exports` section so that ts can access the types in `NodeNext` mode