### PR TITLE
feat: when NonEmptyArray is being passed to uniqueBy() the output is always a NonEmptyArray

### DIFF
--- a/.changeset/giant-crabs-act.md
+++ b/.changeset/giant-crabs-act.md
@@ -1,0 +1,5 @@
+---
+'array-fp-utils': minor
+---
+
+When a NonEmptyArray is being passed to uniqueBy() the output will always be a NonEmptyArray

--- a/lib/isDistinctArray/isDistinctArray.ts
+++ b/lib/isDistinctArray/isDistinctArray.ts
@@ -1,6 +1,6 @@
 import { Primitive } from '../types';
 
-export function isDistinctArray(arr: Readonly<Array<Primitive>>): boolean {
+export function isDistinctArray(arr: ReadonlyArray<Primitive>): boolean {
   const set = new Set(arr);
   return arr.length === set.size;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,7 @@
 export type NonEmptyArray<T> = [T, ...T[]];
 
-export type NonEmptyArrayAlt<A> = Array<A> & {
-  0: A;
+export type NonEmptyArrayAlt<T> = Array<T> & {
+  0: T;
 };
 
 export type Primitive =

--- a/lib/uniqueBy/uniqueBy.test.ts
+++ b/lib/uniqueBy/uniqueBy.test.ts
@@ -1,5 +1,7 @@
-import { pipe } from 'fp-ts/lib/function';
+import { identity, pipe } from 'fp-ts/lib/function';
+import { expectType } from 'ts-expect';
 
+import { NonEmptyArray, NonEmptyArrayAlt } from '../types';
 import { uniqueBy } from './uniqueBy';
 
 const mockData = [
@@ -123,6 +125,81 @@ describe('uniqueBy()', () => {
           "country": "United States",
           "id": 4,
           "revenue": 181211002,
+        },
+        {
+          "company": "Dynava",
+          "country": "United Kingdom",
+          "id": 5,
+          "revenue": 42858525,
+        },
+      ]
+    `);
+  });
+
+  it('accepts empty array as input', () => {
+    const expected = pipe([], uniqueBy(identity));
+
+    expectType<Array<never>>(expected);
+    expect(expected).toEqual([]);
+  });
+
+  it('accepts NonEmptyArray as input', () => {
+    type T = NonEmptyArray<typeof mockData[number]>;
+
+    const expected = pipe(
+      mockData as T,
+      uniqueBy((item) => item.country)
+    );
+
+    expectType<T>(expected);
+
+    expect(expected).toMatchInlineSnapshot(`
+      [
+        {
+          "company": "Flashset",
+          "country": "Greece",
+          "id": 1,
+          "revenue": 48401958,
+        },
+        {
+          "company": "Tagtune",
+          "country": "United States",
+          "id": 4,
+          "revenue": 64066240,
+        },
+        {
+          "company": "Dynava",
+          "country": "United Kingdom",
+          "id": 5,
+          "revenue": 42858525,
+        },
+      ]
+    `);
+  });
+
+  it('accepts NonEmptyArrayAlt as input', () => {
+    type T = NonEmptyArrayAlt<typeof mockData[number]>;
+
+    const expected = pipe(
+      mockData as T,
+      uniqueBy((item) => item.country)
+    );
+
+    expectType<T>(expected);
+
+    expect(expected).toMatchInlineSnapshot(`
+      [
+        {
+          "company": "Flashset",
+          "country": "Greece",
+          "id": 1,
+          "revenue": 48401958,
+        },
+        {
+          "company": "Tagtune",
+          "country": "United States",
+          "id": 4,
+          "revenue": 64066240,
         },
         {
           "company": "Dynava",

--- a/lib/uniqueBy/uniqueBy.ts
+++ b/lib/uniqueBy/uniqueBy.ts
@@ -1,23 +1,46 @@
+import { NonEmptyArray, NonEmptyArrayAlt } from '../types';
+
+export function _uniqueBy<
+  T extends
+    | ReadonlyArray<unknown>
+    | Readonly<NonEmptyArray<unknown>>
+    | Readonly<NonEmptyArrayAlt<unknown>>,
+  K
+>(
+  arr: T,
+  getUniqueKey: (value: T[number]) => K,
+  reduceValue: (prevValue: T[number], nextValue: T[number]) => T[number] = (
+    prevValue
+  ) => prevValue
+): T {
+  const map = new Map<K, T[number]>();
+
+  for (const value of arr) {
+    const key = getUniqueKey(value);
+    const existingValue = map.get(key);
+
+    if (!existingValue) {
+      map.set(key, value);
+    } else {
+      map.set(key, reduceValue(existingValue, value));
+    }
+  }
+
+  return Array.from(map.values()) as T;
+}
+
 export const uniqueBy =
-  <ValueType, KeyType>(
-    getUniqueKey: (value: ValueType) => KeyType,
-    reduceValue: (prevValue: ValueType, nextValue: ValueType) => ValueType = (
+  <
+    T extends
+      | ReadonlyArray<unknown>
+      | Readonly<NonEmptyArray<unknown>>
+      | Readonly<NonEmptyArrayAlt<unknown>>,
+    K
+  >(
+    getUniqueKey: (value: T[number]) => K,
+    reduceValue: (prevValue: T[number], nextValue: T[number]) => T[number] = (
       prevValue
     ) => prevValue
   ) =>
-  (arr: Readonly<Array<ValueType>>): Array<ValueType> => {
-    const map = arr.reduce((acc, value) => {
-      const key = getUniqueKey(value);
-      const existingValue = acc.get(key);
-
-      if (!existingValue) {
-        acc.set(key, value);
-      } else {
-        acc.set(key, reduceValue(existingValue, value));
-      }
-
-      return acc;
-    }, new Map<KeyType, ValueType>());
-
-    return Array.from(map.values());
-  };
+  (arr: T): T =>
+    _uniqueBy(arr, getUniqueKey, reduceValue);


### PR DESCRIPTION
Extend the `uniqueBy` function to handle `NonEmptyArray` and `NonEmptyArrayAlt` input.