### PR TITLE
ci: fix usage of actions/cache@v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: npm-cache
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: '**/build'
           key: ${{ runner.os }}-build-${{ github.sha }}
@@ -58,13 +58,13 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: npm-cache
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: '**/build'
           key: ${{ runner.os }}-build-${{ github.sha }}


### PR DESCRIPTION
`actions/cache@v2` no longer works (see [this](https://github.com/causaly/array-fp-utils/actions/runs/13694140905/job/38292710896?pr=31), for example).

This replaces usage with `v4`.